### PR TITLE
Update caliban to 2.4.3

### DIFF
--- a/graphql/caliban/build.sbt
+++ b/graphql/caliban/build.sbt
@@ -7,8 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "scala-caliban",
     libraryDependencies ++= Seq(
-      "dev.zio"                               %% "zio-http"              % "3.0.0-RC2",
-      "com.github.ghostdogpr"                 %% "caliban"               % "2.4.3",
+      "com.github.ghostdogpr"                 %% "caliban-quick"         % "2.4.3",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.24.4",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.24.4" % Provided
     )

--- a/graphql/caliban/src/main/scala/Main.scala
+++ b/graphql/caliban/src/main/scala/Main.scala
@@ -1,40 +1,12 @@
 import caliban.*
-import com.github.plokhotnyuk.jsoniter_scala.core.*
+import caliban.quick.*
 import zio.*
-import zio.http.Method.POST
-import zio.http.{Client as _, *}
 
 object Main extends ZIOAppDefault {
-
-  override val bootstrap: ZLayer[Any, Any, Any] =
-    Runtime.removeDefaultLoggers ++ Runtime.setExecutor(Executor.makeDefault(false))
-
   private val api = graphQL(RootResolver(Query(Service.posts)))
 
-  def run = {
-    for
-      interpreter <- api.interpreter
-      handleRequest = new RequestHandler(interpreter)
-      routes        = Http.collectZIO { case req @ POST -> Root / "graphql" => handleRequest(req) }
-      _ <- Server.serve(routes)
-    yield ()
-  }.provide(
-    Server.live,
-    ZLayer.succeed(Server.Config.default.port(8000).logWarningOnFatalError(false)),
-    Service.layer,
-    Client.live
-  )
-
-}
-
-final class RequestHandler(interpreter: GraphQLInterpreter[Service, CalibanError]) {
-  private val contentTypeJson: Headers = Headers(Header.ContentType(MediaType.application.json).untyped)
-
-  def apply(request: Request): URIO[Service, Response] = {
-    for {
-      arr  <- request.body.asArray.orDie
-      resp <- interpreter.executeRequest(readFromArray[GraphQLRequest](arr))
-    } yield Response(Status.Ok, contentTypeJson, Body.fromChunk(Chunk.fromArray(writeToArray(resp)))).withServerTime
-  }
-
+  def run =
+    api
+      .runServer(8000, apiPath = "/graphql")
+      .provide(Service.layer, Client.live)
 }


### PR DESCRIPTION
Hey guys, just updating the caliban version to the latest release. In this release we added an opinionated, fully GraphQL-over-HTTP compliant adapter that prioritises UX and performance over customisability. It uses zio-http under the hood which is by far the most performant server available in Scala at the moment (big thanks @tusharmath!).

As a side note, this work was largely inspired by the process of adding Caliban to the benchmarks here and the simplicity of tailcall itself, so thank you!