### PR TITLE
[Caliban] Use apache's async http client

### DIFF
--- a/graphql/caliban/build.sbt
+++ b/graphql/caliban/build.sbt
@@ -5,10 +5,15 @@ ThisBuild / organizationName := "example"
 
 lazy val root = (project in file("."))
   .settings(
-    name := "scala-caliban",
+    name       := "scala-caliban",
+    run / fork := true,
+    run / javaOptions ++= Seq("-Xms4G", "-Xmx4G"),
     libraryDependencies ++= Seq(
       "com.github.ghostdogpr"                 %% "caliban-quick"         % "2.4.3",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.25.0",
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.25.0" % Provided
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.25.0" % Provided,
+      "org.apache.httpcomponents.client5"      % "httpclient5"           % "5.2.2"
     )
   )
+
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")


### PR DESCRIPTION
Offers slightly improved throughput than the JDK11's stock HTTP client. Ideally we'd like to use zio-http's (Netty) client but unfortunately it doesn't seem to work with the proxy 😕