### PR TITLE
chore: install tailcall from npm

### DIFF
--- a/graphql/tailcall/build.sh
+++ b/graphql/tailcall/build.sh
@@ -1,2 +1,4 @@
-cd ../../../tailcall
-cargo build --release
+#!/bin/bash
+pwd
+cd graphql/tailcall
+npm install

--- a/graphql/tailcall/package-lock.json
+++ b/graphql/tailcall/package-lock.json
@@ -1,0 +1,216 @@
+{
+  "name": "tailcall",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tailcall",
+      "license": "ISC",
+      "dependencies": {
+        "@tailcallhq/tailcall": "0.82.19"
+      }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.3.0.tgz",
+      "integrity": "sha512-lHKK8M5CTcpFj2hZDB3wIjb0KAbEOgDmiJGDv1WBRfQgRm/a8/XMEkG/N1iM01xgbUDsPQwi42D+dFo1XPAKew==",
+      "hasInstallScript": true
+    },
+    "node_modules/@tailcallhq/core-darwin-arm64": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-darwin-arm64/-/core-darwin-arm64-0.82.19.tgz",
+      "integrity": "sha512-qDi4T6K7DNwxgw0GMNl6Ojq71hrDqVEru7jHrhiGKINe2x89cJcur9KgJRDjLD0dILZlulzermXescec/VXjWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-darwin-x64": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-darwin-x64/-/core-darwin-x64-0.82.19.tgz",
+      "integrity": "sha512-ImcMXTPK0Tt59dBVmIPQwsq+sD8XTi7UDSnK7Nnm6FMx2jUiJZ4XXWFuPEl+GspEJJwhKnQIp8t77iByuvz2XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-linux-arm64-gnu": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-linux-arm64-gnu/-/core-linux-arm64-gnu-0.82.19.tgz",
+      "integrity": "sha512-m8PgEEdxp/iOIcHanKGeduu+qSYp6Dw5pxJh3MHiB0LBuux6xWpnPI941RQjPNzi1eIF48GLGqOy/K4Kj55fUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-linux-arm64-musl": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-linux-arm64-musl/-/core-linux-arm64-musl-0.82.19.tgz",
+      "integrity": "sha512-Szz0kiZ412NjnorzztnHg6E0IrY+LzfZdgjtsOR8CaEuj6N0PYVsEVuRSNlxwY5WIzGOXIRV+TliQQ/Y/DttqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-linux-ia32-gnu": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-linux-ia32-gnu/-/core-linux-ia32-gnu-0.82.19.tgz",
+      "integrity": "sha512-MpB9g3aAeKomd2tsF55RtJt5f5elzV+l00c05Q8pthNpfEeCvBdBoUDqSyDk/1a4EDjCL9O3i662+TztO6+UzQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-linux-x64-gnu": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-linux-x64-gnu/-/core-linux-x64-gnu-0.82.19.tgz",
+      "integrity": "sha512-1EQhHcPOHTfvpE58YTUFk9o+fKWypDHBVkFPpefAw7/iH4Jy/12T7rKmFKzJHzXHddOUVR8mSIZT4QpeJdFB3A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-linux-x64-musl": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-linux-x64-musl/-/core-linux-x64-musl-0.82.19.tgz",
+      "integrity": "sha512-O3v9sLv/xNtqI/wWlYoguOJhcql+Qc3yYQpXyRrC+RsZf4udonwnTPRWLdfUMfOxh1V77dvhwZRc/aPG4SCimQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall"
+      }
+    },
+    "node_modules/@tailcallhq/core-win32-arm64-msvc": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-win32-arm64-msvc/-/core-win32-arm64-msvc-0.82.19.tgz",
+      "integrity": "sha512-YdCLRfh7p2N/L5ZJ92CyvI95pUhESaK+UGq2FN2nkN0Z39J4lvC0vVMazI04OeIvf5CwNz9BTmRi3nuMrihrxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall.exe"
+      }
+    },
+    "node_modules/@tailcallhq/core-win32-ia32-gnu": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-win32-ia32-gnu/-/core-win32-ia32-gnu-0.82.19.tgz",
+      "integrity": "sha512-Z8t83SjGsHsvJGXBLS4OcUPI3j7JnG/3NO+u7sCCmVP1PnxYuO2X2SK/8OPUSfvDEmDvYvwdTmpmoFNuTt3p3g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall.exe"
+      }
+    },
+    "node_modules/@tailcallhq/core-win32-x64-gnu": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-win32-x64-gnu/-/core-win32-x64-gnu-0.82.19.tgz",
+      "integrity": "sha512-EGsKp07er0ppRaX21OH+Su34j9vDJ9gJ3lDgB605+jjVQsNknx3gMtc9Dg7BpeaUqHMoobqUmKWH3SNg3+M0Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall.exe"
+      }
+    },
+    "node_modules/@tailcallhq/core-win32-x64-msvc": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/core-win32-x64-msvc/-/core-win32-x64-msvc-0.82.19.tgz",
+      "integrity": "sha512-u9UJTDXA3uLnM9KIm1JSwPkPd5YkhBUNBdqY87ntbvQrGmpDQgxG2VHdMYR6EjwAqXevuye3OGgzhAPhJcEfdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "tailcall": "bin/tailcall.exe"
+      }
+    },
+    "node_modules/@tailcallhq/tailcall": {
+      "version": "0.82.19",
+      "resolved": "https://registry.npmjs.org/@tailcallhq/tailcall/-/tailcall-0.82.19.tgz",
+      "integrity": "sha512-wMt1q11Qns+6JurRBd7ovgIoIfkXl+ap6UwkyYlvEHJr1P0zy4WDlefPwxqt0fMVI6+laUds1qap/v1KNEGNrg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@scarf/scarf": "^1.3.0",
+        "detect-libc": "^2.0.2"
+      },
+      "optionalDependencies": {
+        "@tailcallhq/core-darwin-arm64": "v0.82.19",
+        "@tailcallhq/core-darwin-x64": "v0.82.19",
+        "@tailcallhq/core-linux-arm64-gnu": "v0.82.19",
+        "@tailcallhq/core-linux-arm64-musl": "v0.82.19",
+        "@tailcallhq/core-linux-ia32-gnu": "v0.82.19",
+        "@tailcallhq/core-linux-x64-gnu": "v0.82.19",
+        "@tailcallhq/core-linux-x64-musl": "v0.82.19",
+        "@tailcallhq/core-win32-arm64-msvc": "v0.82.19",
+        "@tailcallhq/core-win32-ia32-gnu": "v0.82.19",
+        "@tailcallhq/core-win32-x64-gnu": "v0.82.19",
+        "@tailcallhq/core-win32-x64-msvc": "v0.82.19"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/graphql/tailcall/package.json
+++ b/graphql/tailcall/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tailcall",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@tailcallhq/tailcall": "0.82.19"
+  }
+}

--- a/graphql/tailcall/run.sh
+++ b/graphql/tailcall/run.sh
@@ -1,3 +1,27 @@
 #!/bin/bash
+
+# Base directory
+
+cd graphql/tailcall
+
 current_dir=$(pwd)
-TAILCALL_LOG_LEVEL=error TC_TRACKER=false $HOME/.tailcall/bin/tailcall start $current_dir/graphql/tailcall/benchmark.graphql
+echo "Current directory: $current_dir"
+
+base_dir="./node_modules"
+
+# Pick the tailcall executable
+for core_dir in $(find "$base_dir" -type d -name "core-*"); do
+    tailcall_executable="${core_dir}/bin/tailcall"
+
+    # Check if the tailcall executable exists
+    if [[ -x "$tailcall_executable" ]]; then
+        echo "Executing $tailcall_executable"
+
+        # Run the executable with the specified arguments
+        TAILCALL_LOG_LEVEL=error TC_TRACKER=false "$tailcall_executable" start $current_dir/benchmark.graphql
+        exit 0
+    fi
+done
+
+echo "tailcall executable not found."
+exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -15,8 +15,8 @@ cd graphql/netflix_dgs
 cd ../../
 
 # For tailcall:
-curl -sSL https://raw.githubusercontent.com/tailcallhq/tailcall/main/install.sh | bash -s -- v0.82.19
-export PATH=$PATH:/root/.tailcall/bin
+cd graphql/tailcall
+npm install
 
 # For caliban
 cd graphql/caliban

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,7 @@ cd ../../
 # For tailcall:
 cd graphql/tailcall
 npm install
+cd ../../
 
 # For caliban
 cd graphql/caliban


### PR DESCRIPTION
renovate doesn't work on tailcall as its installed from the bash leverage package json and npm to make renovate work