### PR TITLE
Remove `zio-http` snapshot dependency

### DIFF
--- a/graphql/caliban/build.sbt
+++ b/graphql/caliban/build.sbt
@@ -9,12 +9,11 @@ lazy val root = (project in file("."))
     run / fork := true,
     run / javaOptions ++= Seq("-Xms4G", "-Xmx4G"),
     libraryDependencies ++= Seq(
-      "com.github.ghostdogpr"                 %% "caliban-quick"         % "2.6.0",
+      "com.github.ghostdogpr"                 %% "caliban-quick"         % "2.7.0",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.29.0",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.29.0" % Provided,
       "org.apache.httpcomponents.client5"      % "httpclient5"           % "5.3.1",
-      "dev.zio"                               %% "zio"                   % "2.1.1",
-      "dev.zio"                               %% "zio-http"              % "3.0.0-RC6+23-5441a052-SNAPSHOT"
+      "dev.zio"                               %% "zio"                   % "2.1.1"
     )
   )
 


### PR DESCRIPTION
There's a new release of Caliban which uses the latest release of `zio-http` (which contains the addition of the `Date` header), so we no longer need to use the snapshot version