### PR TITLE
[Caliban] Use a function instead of effect for `greet`

### DIFF
--- a/graphql/caliban/src/main/scala/Api.scala
+++ b/graphql/caliban/src/main/scala/Api.scala
@@ -9,7 +9,7 @@ object ServiceSchema extends SchemaDerivation[Service]
 
 case class Query(
     posts: RIO[Service, List[Post]],
-    greet: UIO[String] = ZIO.succeed("Hello World!")
+    greet: () => String = () => "Hello World!"
 ) derives ServiceSchema.SemiAuto
 
 case class User(


### PR DESCRIPTION
In Caliban, we don't use effects when there is no need for an asynchronous / blocking operation