### PR TITLE
fix: update `nodejs` installation cd to ensure LTS distribution

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,8 +18,10 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install the latest LTS version of Node.js
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
-  apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x -o nodesource_setup.sh && \
+    bash nodesource_setup.sh && \
+    apt-get install -y nodejs && \
+    rm nodesource_setup.sh
 
 # Install Go
 RUN wget https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz -O- | tar xz -C /usr/local


### PR DESCRIPTION
/claim #18

This latter approach is more maintainable and cleaner.  It follows best practices by handling temporary files explicitly and ensuring the Docker image remains as minimal as possible.

It also follows the official documentation of NodeJS of the installation guide

Reference:

https://github.com/nodesource/distributions/blob/master/README.md#using-ubuntu-nodejs-lts