### PR TITLE
Run caliban via JAR directly

### DIFF
--- a/graphql/caliban/build.sbt
+++ b/graphql/caliban/build.sbt
@@ -8,6 +8,12 @@ lazy val root = (project in file("."))
     name       := "scala-caliban",
     run / fork := true,
     run / javaOptions ++= Seq("-Xms4G", "-Xmx4G"),
+    assembly / mainClass := Some("Main"),
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "MANIFEST.MF")                  => MergeStrategy.discard
+      case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
+      case x                                                    => MergeStrategy.first
+    },
     libraryDependencies ++= Seq(
       "com.github.ghostdogpr"                 %% "caliban-quick"         % "2.9.0",
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.32.0",

--- a/graphql/caliban/project/plugins.sbt
+++ b/graphql/caliban/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")

--- a/graphql/caliban/run.sh
+++ b/graphql/caliban/run.sh
@@ -4,4 +4,5 @@ set -e
 
 pwd
 cd graphql/caliban
-./sbt run
+JAR_FILE=$(find . -name "scala-caliban-assembly*")
+java -Xms4G -Xmx4G -jar $JAR_FILE

--- a/graphql/caliban/setup.sh
+++ b/graphql/caliban/setup.sh
@@ -2,5 +2,5 @@
 
 # For caliban
 cd graphql/caliban
-./sbt compile
+./sbt assembly
 cd ../../

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ cd ../../
 
 # For caliban
 cd graphql/caliban
-./sbt compile
+./sbt assembly
 cd ../../
 
 # For async-graphql


### PR DESCRIPTION
Running via `sbt` requires the SBT server process to run in the background as well, which consumes some resources. While I doubt it'll make any meaningful difference, it's still better to avoid the overhead in a benchmarking setup.

Leaving as draft until CI passes in case I missed something in the configuration